### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 An integration that allows Claude Desktop to interact with Hacker News using the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-hackernews">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-hackernews/badge" alt="mcp-claude-hackernews MCP server" />
+</a>
+
 ## Features
 
 - Browse latest stories from Hacker News

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 [![smithery badge](https://smithery.ai/badge/@imprvhub/mcp-claude-spotify)](https://smithery.ai/server/@imprvhub/mcp-claude-hackernews)
 
-An integration that allows Claude Desktop to interact with Hacker News using the Model Context Protocol (MCP).
-
-<a href="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-hackernews">
+<table style="border-collapse: collapse; width: 100%;">
+<tr>
+<td style="width: 50%; padding: 15px; vertical-align: middle; border: none;">An integration that allows Claude Desktop to interact with Spotify using the Model Context Protocol (MCP).</td>
+<td style="width: 50%; padding: 0; vertical-align: middle; border: none;"><a href="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-hackernews">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-hackernews/badge" alt="mcp-claude-hackernews MCP server" />
-</a>
+</a></td>
+</tr>
+</table>
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [mcp-claude-hackernews](https://glama.ai/mcp/servers/@imprvhub/mcp-claude-hackernews) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-hackernews">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imprvhub/mcp-claude-hackernews/badge" alt="mcp-claude-hackernews MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.